### PR TITLE
Better configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+*.dat

--- a/agent.go
+++ b/agent.go
@@ -3,6 +3,7 @@ package quantum
 import (
 	"os"
 
+	"github.com/doubledutch/lager"
 	"github.com/doubledutch/mux"
 )
 
@@ -18,4 +19,5 @@ type AgentConn interface {
 	mux.Server
 	Logs() chan string
 	Signals() chan os.Signal
+	Lager() lager.Lager
 }

--- a/agent/conn.go
+++ b/agent/conn.go
@@ -46,7 +46,7 @@ func NewConn(conn net.Conn, config *quantum.ConnConfig) (*Conn, error) {
 	}
 
 	// Send up receiver for signals
-	sigR := ac.Pool().NewReceiver(ac.SigCh)
+	sigR := mux.NewSignalReceiver(ac.SigCh, config.Pool)
 	srv.Receive(mux.SignalType, sigR)
 
 	requestR := quantum.NewRequestReceiver(ac.RequestCh)
@@ -65,6 +65,12 @@ func (conn *Conn) Signals() chan os.Signal {
 // Logs returns the logs channel of the connection
 func (conn *Conn) Logs() chan string {
 	return conn.OutCh
+}
+
+// Lager returns the Lager of the connection, allowing jobs
+// to log to the agent
+func (conn *Conn) Lager() lager.Lager {
+	return conn.lgr
 }
 
 // Serve processes a connection and serves the response

--- a/agent/conn.go
+++ b/agent/conn.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"os"
 	"runtime/debug"
-	"time"
 
 	"github.com/doubledutch/lager"
 	"github.com/doubledutch/mux"
@@ -26,24 +25,13 @@ type Conn struct {
 	lgr lager.Lager
 }
 
-type connConfig struct {
-	Timeout time.Duration
-	Pool    mux.Pool
-	Lager   lager.Lager
-}
-
 // NewConn returns a new Connection connected to the specified io.ReadWriter
-func NewConn(conn net.Conn, config *connConfig) (*Conn, error) {
-	muxConfig := new(mux.Config)
-	// TODO: Verify not null
-	if config != nil {
-		muxConfig.Lager = config.Lager
-		muxConfig.Timeout = config.Timeout
-	} else {
-		muxConfig = mux.DefaultConfig()
+func NewConn(conn net.Conn, config *quantum.ConnConfig) (*Conn, error) {
+	if config == nil {
+		config = quantum.DefaultConnConfig()
 	}
 
-	srv, err := config.Pool.NewServer(conn, muxConfig)
+	srv, err := config.Pool.NewServer(conn, config.ToMux())
 	if err != nil {
 		return nil, err
 	}

--- a/agent/server.go
+++ b/agent/server.go
@@ -2,18 +2,19 @@ package agent
 
 import (
 	"errors"
-	"flag"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/doubledutch/quantum"
-	"github.com/doubledutch/quantum/consul"
 	"github.com/doubledutch/quantum/inmemory"
 
 	"github.com/doubledutch/lager"
+	"github.com/doubledutch/mux"
 	"github.com/doubledutch/mux/gob"
 )
 
@@ -24,42 +25,22 @@ var (
 
 // Config encapsulates configuration for an agent
 type Config struct {
-	*quantum.Config
-	Port   string
-	Server string
+	Pool    mux.Pool
+	Lager   lager.Lager
+	Timeout time.Duration
 
-	Levels string
+	Port string
 
 	Registry    quantum.Registry
 	Registrator quantum.Registrator
 }
 
-// RegisterFlags takes defaultFlags and registers quantum agent flags
-func RegisterFlags(defaultFlags *Config) *Config {
-	config := new(Config)
-	config.Config = quantum.DefaultConfig()
-	if defaultFlags == nil {
-		defaultFlags = new(Config)
-	}
-	if defaultFlags.Config == nil {
-		defaultFlags.Config = quantum.DefaultConfig()
-	}
-
-	if defaultFlags.Levels == "" {
-		defaultFlags.Levels = "IE"
-	}
-
-	flag.StringVar(&config.Port, "p", defaultFlags.Port, "port to run on")
-	// This is required to create the Registrator
-	flag.StringVar(&config.Server, "s", defaultFlags.Server, "quantum service server to register with")
-	flag.StringVar(&config.Levels, "log", defaultFlags.Levels, "log levels")
-
-	return config
-}
-
 // Agent routes job requests to jobs, and runs the jobs with the request
 type Agent struct {
-	config *quantum.Config
+	pool mux.Pool
+	lgr  lager.Lager
+
+	timeout time.Duration
 
 	port  string
 	done  chan struct{}
@@ -67,43 +48,46 @@ type Agent struct {
 
 	quantum.Registry
 	registrator quantum.Registrator
-
-	lgr lager.Lager
 }
 
 // New creates a new Agent with the specified port
 func New(config *Config) quantum.Agent {
-	lager := lager.NewLogLager(&lager.LogConfig{
-		Levels: lager.LevelsFromString(config.Levels),
-		Output: os.Stdout,
-	})
+	if config.Pool == nil {
+		config.Pool = new(gob.Pool)
+	}
 
-	if config.Config == nil {
-		config.Config = &quantum.Config{
-			Pool:  new(gob.Pool),
-			Lager: lager,
-		}
+	if config.Lager == nil {
+		config.Lager = lager.NewLogLager(&lager.LogConfig{
+			Levels: lager.LevelsFromString("IE"),
+			Output: os.Stdout,
+		})
 	}
 
 	if config.Registry == nil {
-		config.Registry = inmemory.NewRegistry()
+		config.Registry = inmemory.NewRegistry(config.Lager)
 	}
 
 	if config.Registrator == nil {
-		config.Registrator = consul.NewRegistrator(config.Server, lager)
+		config.Registrator = inmemory.NewRegistrator()
 	}
 
-	return &Agent{
-		config: config.Config,
-		port:   config.Port,
-		done:   make(chan struct{}),
-		sigCh:  make(chan os.Signal, 1),
+	if config.Timeout == 0 {
+		config.Timeout = 100 * time.Millisecond
+	}
 
-		// These should be injected as defaults
+	fmt.Println(config)
+
+	return &Agent{
+		pool:    config.Pool,
+		lgr:     config.Lager,
+		timeout: config.Timeout,
+
 		Registry:    config.Registry,
 		registrator: config.Registrator,
 
-		lgr: lager,
+		port:  config.Port,
+		done:  make(chan struct{}),
+		sigCh: make(chan os.Signal, 1),
 	}
 }
 
@@ -111,11 +95,17 @@ func New(config *Config) quantum.Agent {
 func (a *Agent) Accept(ln net.Listener) error {
 	netConn, err := ln.Accept()
 	if err != nil {
+		a.lgr.Errorf("Error net connection: %s", err)
 		return err
 	}
 
-	conn, err := NewConn(netConn, a.config)
+	conn, err := NewConn(netConn, &connConfig{
+		Timeout: a.timeout,
+		Lager:   a.lgr,
+		Pool:    a.pool,
+	})
 	if err != nil {
+		a.lgr.Errorf("Error creating agent conn: %s", err)
 		return err
 	}
 
@@ -155,11 +145,14 @@ func (a *Agent) Start() error {
 		}
 	}()
 
+	a.lgr.Debugf("Registering")
 	if err := a.registrator.Register(NewPort(a.port).Int(), a); err != nil {
-		a.lgr.Warnf("Failed to announce services: %s\n", err)
+		a.lgr.Errorf("Failed to announce services: %s\n", err)
+		return err
 	}
 
 	// Blocks
+	a.lgr.Debugf("ListenAndServe block")
 	return quantum.ListenAndServe(a, a.port, a.lgr)
 }
 

--- a/agent/server.go
+++ b/agent/server.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -68,8 +67,6 @@ func New(config *Config) quantum.Agent {
 	if config.Timeout == 0 {
 		config.Timeout = 100 * time.Millisecond
 	}
-
-	fmt.Println(config)
 
 	return &Agent{
 		ConnConfig: config.ConnConfig,

--- a/agent/server.go
+++ b/agent/server.go
@@ -87,7 +87,6 @@ func New(config *Config) quantum.Agent {
 func (a *Agent) Accept(ln net.Listener) error {
 	netConn, err := ln.Accept()
 	if err != nil {
-		a.Lager.Errorf("Error net connection: %s", err)
 		return err
 	}
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package quantum
 
 import (
 	"os"
+	"time"
 
 	"github.com/doubledutch/mux"
 )
@@ -9,6 +10,7 @@ import (
 // Client creates ClientConns
 type Client interface {
 	Dial(address string) (ClientConn, error)
+	DialTimeout(address string, time time.Duration) (ClientConn, error)
 }
 
 // ClientConn is a connection to an AgentConn

--- a/client/conn.go
+++ b/client/conn.go
@@ -9,7 +9,7 @@ import (
 	"github.com/doubledutch/quantum"
 )
 
-// Conn wraps a Connection
+// Conn implements quantum.ClientConn
 type Conn struct {
 	mux.Client
 

--- a/client/dialer.go
+++ b/client/dialer.go
@@ -9,17 +9,13 @@ import (
 
 // Client sends requests to Server and reads the response
 type Client struct {
-	config *quantum.Config
+	*quantum.ConnConfig
 }
 
 // New returns a new Client with the specified host and port
-func New(config *quantum.Config) quantum.Client {
-	if config == nil {
-		config = quantum.DefaultConfig()
-	}
-
+func New(config *quantum.ConnConfig) quantum.Client {
 	return &Client{
-		config: config,
+		ConnConfig: config,
 	}
 }
 
@@ -30,7 +26,7 @@ func (c *Client) Dial(address string) (quantum.ClientConn, error) {
 		return nil, fmt.Errorf("dial err: %s", err)
 	}
 
-	conn, err := NewConn(netConn, c.config)
+	conn, err := NewConn(netConn, c.ConnConfig)
 
 	return conn, err
 }

--- a/client/dialer.go
+++ b/client/dialer.go
@@ -7,33 +7,19 @@ import (
 	"github.com/doubledutch/quantum"
 )
 
-// Config contains info for running the client
-type Config struct {
-	// TODO: This naming sucks...
-	Config *quantum.Config
-}
-
-// DefaultClientConfig is the default client config
-func DefaultClientConfig() *Config {
-	return &Config{
-		Config: quantum.DefaultConfig(),
-	}
-}
-
 // Client sends requests to Server and reads the response
 type Client struct {
 	config *quantum.Config
 }
 
 // New returns a new Client with the specified host and port
-func New(config *Config) quantum.Client {
+func New(config *quantum.Config) quantum.Client {
 	if config == nil {
-		config = DefaultClientConfig()
-	} else if config.Config == nil {
-		config.Config = quantum.DefaultConfig()
+		config = quantum.DefaultConfig()
 	}
+
 	return &Client{
-		config: config.Config,
+		config: config,
 	}
 }
 

--- a/client/dialer.go
+++ b/client/dialer.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"fmt"
 	"net"
+	"time"
 
 	"github.com/doubledutch/quantum"
 )
@@ -19,14 +19,23 @@ func New(config *quantum.ConnConfig) quantum.Client {
 	}
 }
 
-// Dial connects to the ClientConfig.addr and returns ClientConn
+// Dial connects to the address and returns quantum.ClientConn
 func (c *Client) Dial(address string) (quantum.ClientConn, error) {
 	netConn, err := net.Dial("tcp", address)
 	if err != nil {
-		return nil, fmt.Errorf("dial err: %s", err)
+		return nil, err
 	}
 
-	conn, err := NewConn(netConn, c.ConnConfig)
+	return NewConn(netConn, c.ConnConfig)
+}
 
-	return conn, err
+// DialTimeout connects to the address and returns quantum.ClientConn, timing out
+// after time
+func (c *Client) DialTimeout(address string, time time.Duration) (quantum.ClientConn, error) {
+	netConn, err := net.DialTimeout("tcp", address, time)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConn(netConn, c.ConnConfig)
 }

--- a/client_resolver.go
+++ b/client_resolver.go
@@ -27,3 +27,21 @@ type ClientResolverConfig struct {
 	Config *Config
 	Server string
 }
+
+// MultiClientResolver implements ClientResolver by trying to resolve a client
+// be iterating through provided ClientResolvers.
+type MultiClientResolver struct {
+	Resolvers []ClientResolver
+}
+
+// Resolve resolves a ResolveRequest by iterating through r.Resolvers
+func (r *MultiClientResolver) Resolve(request ResolveRequest) (conn ClientConn, err error) {
+	for _, resolver := range r.Resolvers {
+		conn, err = resolver.Resolve(request)
+		if err == nil {
+			break
+		}
+	}
+
+	return conn, err
+}

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ var (
 	ErrInvalidPool = errors.New("Invalid Config Pool")
 )
 
-// Config represents configuration for a quantum component
+// Config represents components required by all quantum components
 type Config struct {
 	Lager lager.Lager
 	Pool  mux.Pool

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package quantum
 
 import (
 	"errors"
+	"time"
 
 	"github.com/doubledutch/lager"
 	"github.com/doubledutch/mux"
@@ -39,5 +40,31 @@ func DefaultConfig() *Config {
 	return &Config{
 		Lager: lager.NewLogLager(nil),
 		Pool:  new(gob.Pool),
+	}
+}
+
+// ConnConfig are configuration settings needed for Conn
+type ConnConfig struct {
+	Timeout time.Duration
+	*Config
+}
+
+// DefaultConnConfig is the default ConnConfig
+func DefaultConnConfig() *ConnConfig {
+	return &ConnConfig{
+		Timeout: 100 * time.Millisecond,
+		Config:  DefaultConfig(),
+	}
+}
+
+// ToMux creates a mux.Config from ConnConfig
+func (c *ConnConfig) ToMux() *mux.Config {
+	if c == nil {
+		return mux.DefaultConfig()
+	}
+
+	return &mux.Config{
+		Timeout: c.Timeout,
+		Lager:   c.Lager,
 	}
 }

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -4,9 +4,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/doubledutch/lager"
 	"github.com/doubledutch/quantum"
 	"github.com/doubledutch/quantum/client"
-	"github.com/doubledutch/lager"
 	"github.com/miekg/dns"
 )
 
@@ -90,9 +90,7 @@ func (cr *ClientResolver) resolveClient(results []resolveResult) (conn quantum.C
 	err = quantum.ErrNoAgents
 	// TODO: Do this concurrently
 	for _, result := range results {
-		client := client.New(&client.Config{
-			Config: cr.config,
-		})
+		client := client.New(cr.config)
 		conn, err = client.Dial(result.address)
 		if err != nil {
 			break

--- a/consul/resolver.go
+++ b/consul/resolver.go
@@ -27,7 +27,7 @@ func NewClientResolver(config quantum.ClientResolverConfig) quantum.ClientResolv
 
 // ClientResolver is a client resolver that leverages Consul's service discovery.
 type ClientResolver struct {
-	config *quantum.Config
+	config *quantum.ConnConfig
 	lgr    lager.Lager
 	server string
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,6 +1,9 @@
 package defaults
 
 import (
+	"os"
+
+	"github.com/doubledutch/lager"
 	"github.com/doubledutch/quantum"
 	"github.com/doubledutch/quantum/consul"
 	"github.com/doubledutch/quantum/inmemory"
@@ -11,7 +14,15 @@ func NewClientResolver(config quantum.ClientResolverConfig) quantum.ClientResolv
 	return consul.NewClientResolver(config)
 }
 
-// NewRegistry returns the default registry
+// NewRegistry returns a default registry
 func NewRegistry() quantum.Registry {
-	return inmemory.NewRegistry()
+	return inmemory.NewRegistry(NewLager())
+}
+
+// NewLager returns a default Lager
+func NewLager() lager.Lager {
+	return lager.NewLogLager(&lager.LogConfig{
+		Levels: lager.LevelsFromString("IE"),
+		Output: os.Stdout,
+	})
 }

--- a/inmemory/registrator.go
+++ b/inmemory/registrator.go
@@ -1,0 +1,35 @@
+package inmemory
+
+import (
+	"strconv"
+
+	"github.com/doubledutch/quantum"
+)
+
+// Registrator registers jobs locally
+type Registrator struct {
+	// Type -> Address
+	Jobs map[string]string
+}
+
+// NewRegistrator creates a new Registrator
+func NewRegistrator() *Registrator {
+	return &Registrator{
+		Jobs: make(map[string]string),
+	}
+}
+
+// Register will register a Registry locally
+func (r *Registrator) Register(port int, reg quantum.Registry) error {
+	for _, t := range reg.Types() {
+		r.Jobs[t] = "0.0.0.0:" + strconv.Itoa(port)
+	}
+
+	return nil
+}
+
+// Deregister will register the jobs locally
+func (r *Registrator) Deregister() error {
+	r.Jobs = nil
+	return nil
+}

--- a/inmemory/registry_test.go
+++ b/inmemory/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/doubledutch/lager"
 	"github.com/doubledutch/quantum"
 )
 
@@ -32,7 +33,7 @@ func (j *testRegistryJob) Run(conn quantum.AgentConn) error {
 }
 
 func TestAgentRouterGet(t *testing.T) {
-	r := NewRegistry()
+	r := NewRegistry(lager.NewLogLager(nil))
 
 	job := &testRegistryJob{}
 	r.Add(job)
@@ -51,7 +52,7 @@ func TestAgentRouterGet(t *testing.T) {
 }
 
 func TestAgentRouterGetErr(t *testing.T) {
-	r := NewRegistry()
+	r := NewRegistry(lager.NewLogLager(nil))
 
 	request := quantum.Request{
 		Type: registryJob,
@@ -64,7 +65,7 @@ func TestAgentRouterGetErr(t *testing.T) {
 }
 
 func TestNewInMemoryRegistryGetErr(t *testing.T) {
-	r := NewRegistry()
+	r := NewRegistry(lager.NewLogLager(nil))
 
 	job := &testRegistryJob{}
 	r.Add(job)

--- a/inmemory/resolver.go
+++ b/inmemory/resolver.go
@@ -9,7 +9,7 @@ import (
 
 // ClientResolverConfig defines
 type ClientResolverConfig struct {
-	Config      *quantum.Config
+	*quantum.ConnConfig
 	Registrator *Registrator
 }
 
@@ -20,16 +20,16 @@ type ClientResolver struct {
 }
 
 // NewClientResolver creates a new ClientResolver using a Registrator.
-func NewClientResolver(config ClientResolverConfig) (quantum.ClientResolver, error) {
-	client := client.New(config.Config)
+func NewClientResolver(config *quantum.ConnConfig, r *Registrator) (quantum.ClientResolver, error) {
+	client := client.New(config)
 
-	if config.Registrator == nil {
+	if r == nil {
 		return nil, errors.New("Registrator required")
 	}
 
 	return &ClientResolver{
 		client:      client,
-		registrator: config.Registrator,
+		registrator: r,
 	}, nil
 }
 

--- a/inmemory/resolver.go
+++ b/inmemory/resolver.go
@@ -1,0 +1,45 @@
+package inmemory
+
+import (
+	"errors"
+
+	"github.com/doubledutch/quantum"
+	"github.com/doubledutch/quantum/client"
+)
+
+// ClientResolverConfig defines
+type ClientResolverConfig struct {
+	Config      *quantum.Config
+	Registrator *Registrator
+}
+
+// ClientResolver provides resolution for jobs that are defined on an agent.
+type ClientResolver struct {
+	client      quantum.Client
+	registrator *Registrator
+}
+
+// NewClientResolver creates a new ClientResolver using a Registrator.
+func NewClientResolver(config ClientResolverConfig) (quantum.ClientResolver, error) {
+	client := client.New(config.Config)
+
+	if config.Registrator == nil {
+		return nil, errors.New("Registrator required")
+	}
+
+	return &ClientResolver{
+		client:      client,
+		registrator: config.Registrator,
+	}, nil
+}
+
+// Resolve resolves a ResolveRequest using Registrator
+func (r *ClientResolver) Resolve(request quantum.ResolveRequest) (quantum.ClientConn, error) {
+	var addr string
+	var ok bool
+	if addr, ok = r.registrator.Jobs[request.Type]; !ok {
+		return nil, quantum.ErrNoAgents
+	}
+
+	return r.client.Dial(addr)
+}

--- a/integration/agent_client_test.go
+++ b/integration/agent_client_test.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
 
+	"github.com/doubledutch/lager"
 	"github.com/doubledutch/quantum"
 	"github.com/doubledutch/quantum/agent"
 	"github.com/doubledutch/quantum/client"
@@ -83,13 +85,18 @@ func TestClientAgent(t *testing.T) {
 	port := ":0"
 	agent := agent.New(&agent.Config{
 		Port: port,
+		Lager: lager.NewLogLager(&lager.LogConfig{
+			Levels: lager.LevelsFromString("DIE"),
+			Output: os.Stdout,
+		}),
 	})
-	agent.Add(&testAgentJob{})
+	agent.Add(new(testAgentJob))
 
 	l, agentAddr := listenTCP()
 	go func() {
 		if err := agent.Accept(l); err != nil {
 			t.Fatal(err)
+			t.FailNow()
 		}
 	}()
 

--- a/integration/agent_client_test.go
+++ b/integration/agent_client_test.go
@@ -1,7 +1,6 @@
 package integration
 
 import (
-	"errors"
 	"log"
 	"net"
 	"os"
@@ -60,12 +59,6 @@ func (s AddStep) Run(state quantum.StateBag) error {
 }
 
 func (s AddStep) Cleanup(state quantum.StateBag) {}
-
-type ErrorStep struct{}
-
-func (s ErrorStep) Run(state quantum.StateBag) error {
-	return errors.New("error")
-}
 
 func (j *testAgentJob) Steps() []quantum.Step {
 	return []quantum.Step{
@@ -135,63 +128,3 @@ func TestClientAgent(t *testing.T) {
 	}
 	wg.Wait()
 }
-
-/*
-func TestClientAgentServer(t *testing.T) {
-	server := NewServer()
-	ls, serverAddr := listenTCP()
-	go func() {
-		// Register agent record
-		if err := server.Accept(ls); err != nil {
-			t.Fatal(err)
-			t.FailNow()
-		}
-		// ClientResolve
-		if err := server.Accept(ls); err != nil {
-			t.Fatal(err)
-			t.FailNow()
-		}
-	}()
-
-	la, agentAddr := listenTCP()
-	parts := strings.Split(agentAddr, ":")
-	agent := NewAgent(":" + parts[1])
-	agent.Register(&testAgentJob{})
-	go func() {
-		if err := agent.Accept(la); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	if err := agent.Announce(serverAddr); err != nil {
-		t.Fatal(err)
-		t.FailNow()
-	}
-
-	cr := NewClientResolver()
-	configs, err := cr.Resolve(serverAddr, "test", serverJob, "{}")
-	if err != nil {
-		t.Fatal(err)
-		t.FailNow()
-	}
-
-	outCh := make(chan string)
-	sigCh := make(chan os.Signal)
-	defer close(sigCh)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		for _ = range outCh {
-			// Consume the channel
-		}
-		wg.Done()
-	}()
-
-	if err := cr.RunWith(configs, outCh, sigCh); err != nil {
-		t.Fatal(err)
-		t.FailNow()
-	}
-	close(outCh)
-	wg.Wait()
-}*/

--- a/job.go
+++ b/job.go
@@ -1,6 +1,7 @@
 package quantum
 
 import (
+	"encoding/json"
 	"errors"
 	"sync"
 
@@ -34,6 +35,16 @@ func NewRequest(rt, rd string) Request {
 // Routable defines an interface for routing an object
 type Routable interface {
 	Type() string
+}
+
+// RoutableRequest creates a Request
+func RoutableRequest(r Routable) Request {
+	b, _ := json.Marshal(r)
+
+	return Request{
+		Type: r.Type(),
+		Data: b,
+	}
 }
 
 // Job is executed by Quantum

--- a/job.go
+++ b/job.go
@@ -92,6 +92,7 @@ func (basic *BasicJob) Run(conn AgentConn) error {
 
 	state := NewStateBag()
 	state.Put("conn", conn)
+	state.Put("ui", NewUI(conn))
 	state.Put("runner", NewBasicRunner())
 
 	runner := &BasicExecutor{Steps: basic.job.Steps()}

--- a/registrator.go
+++ b/registrator.go
@@ -1,7 +1,40 @@
 package quantum
 
+import "github.com/hashicorp/go-multierror"
+
 // Registrator registers and deregisters services
 type Registrator interface {
 	Register(port int, reg Registry) error
 	Deregister() error
+}
+
+// MultiRegistrator holds multiple Registry instances
+type MultiRegistrator struct {
+	Registrators []Registrator
+}
+
+// Register calls Register on Registries
+func (r *MultiRegistrator) Register(port int, reg Registry) error {
+	var result error
+
+	for _, registrator := range r.Registrators {
+		if err := registrator.Register(port, reg); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result
+}
+
+// Deregister calls Deregister on Registries
+func (r *MultiRegistrator) Deregister() error {
+	var result error
+
+	for _, registrator := range r.Registrators {
+		if err := registrator.Deregister(); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result
 }

--- a/ui.go
+++ b/ui.go
@@ -1,65 +1,35 @@
 package quantum
 
-import "log"
+import "github.com/doubledutch/lager"
 
-// UI handles sending logs to the client, the server (where it's used), or both
+// UI handles sending logs to the client and agent
 type UI interface {
-	Log(log string)
-	LogClient(log string)
-	SetClient(client chan string)
-	LogBoth(log string)
-}
-
-// UIConfig is configuration for UI
-type UIConfig struct {
-	System *log.Logger
-	Client chan string
-}
-
-// DefaultUIConfig creates the default UI config
-func DefaultUIConfig() *UIConfig {
-	return new(UIConfig)
+	lager.Lager
+	Client(log string)
+	Both(log string)
 }
 
 // NewUI creates a new UI
-func NewUI(config *UIConfig) UI {
-	if config == nil {
-		config = DefaultUIConfig()
+func NewUI(conn AgentConn) UI {
+	return &BasicUI{
+		Lager:    conn.Lager(),
+		clientCh: conn.Logs(),
 	}
-	return NewBasicUI(config)
 }
 
 // BasicUI is a simple implementation of UI
 type BasicUI struct {
-	system *log.Logger
-	client chan string
+	lager.Lager
+	clientCh chan string
 }
 
-// NewBasicUI creates a new basic UI
-func NewBasicUI(config *UIConfig) UI {
-	return &BasicUI{
-		system: config.System,
-		client: config.Client,
-	}
+// Client logs to the client
+func (ui *BasicUI) Client(log string) {
+	ui.clientCh <- log
 }
 
-// LogClient logs to the client
-func (ui *BasicUI) LogClient(log string) {
-	ui.client <- log
-}
-
-// SetClient updates where the UI sends client logs
-func (ui *BasicUI) SetClient(client chan string) {
-	ui.client = client
-}
-
-// Log logs to the local logger
-func (ui *BasicUI) Log(log string) {
-	ui.system.Print(log)
-}
-
-// LogBoth logs both locally and the client
-func (ui *BasicUI) LogBoth(log string) {
-	ui.LogClient(log)
-	ui.Log(log)
+// Both logs to both the agent and the client
+func (ui *BasicUI) Both(log string) {
+	ui.Client(log)
+	ui.Infof(log)
 }


### PR DESCRIPTION
- Use `lager.Lager` for logs
- Make configuration more straightforward
  - `Config` as a base config.
  - `ConnConfig` as connection configuration
- Add `MultiRegistrator` and `MultiClientResolver` to allow for multiple layers of resolution. For example: registering jobs locally and with Consul, resolving clients locally then with Consul. 
