### PR TITLE
consul resolver update

### DIFF
--- a/consul/registrator.go
+++ b/consul/registrator.go
@@ -2,42 +2,46 @@ package consul
 
 import (
 	"code.google.com/p/go-uuid/uuid"
-	"github.com/doubledutch/quantum"
 	"github.com/doubledutch/lager"
+	"github.com/doubledutch/quantum"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 )
 
 // NewRegistrator creates a Registrator
-func NewRegistrator(address string, lgr lager.Lager) quantum.Registrator {
+func NewRegistrator(httpAddr string, lgr lager.Lager) quantum.Registrator {
 	return &Registrator{
-		address: address,
-		lgr:     lgr,
+		httpAddr: httpAddr,
+		lgr:      lgr,
 	}
 }
 
 // Registrator uses consul to implement quantum.Registrator
 type Registrator struct {
 	serviceIDs []string
-	address    string
+	httpAddr   string
+
+	client *api.Client
 
 	lgr lager.Lager
 }
 
 // Register will register types with Consul
 func (r *Registrator) Register(port int, reg quantum.Registry) error {
-	client, err := api.NewClient(&api.Config{
-		Address: r.address,
-	})
-	if err != nil {
-		r.lgr.Errorf("Unable to connect to Consul: %s\n", err)
-		return err
+	if r.client == nil {
+		var err error
+		r.client, err = api.NewClient(&api.Config{
+			Address: r.httpAddr,
+		})
+		if err != nil {
+			r.lgr.Errorf("Unable to connect to Consul: %s\n", err)
+			return err
+		}
 	}
-
 	merr := &multierror.Error{}
 
 	// Relies on local consul agent
-	agent := client.Agent()
+	agent := r.client.Agent()
 	for _, jobType := range reg.Types() {
 		ID := uuid.New()
 		// We may need to set the ID ourselves to guarantee it's unique
@@ -60,14 +64,7 @@ func (r *Registrator) Register(port int, reg quantum.Registry) error {
 // Deregister deregisters our serviceIDs with Consul
 func (r *Registrator) Deregister() error {
 	merr := &multierror.Error{}
-	client, err := api.NewClient(&api.Config{
-		Address: r.address,
-	})
-	if err != nil {
-		r.lgr.Errorf("[ERROR] Unable to connect to Consul: %s\n", err)
-		return err
-	}
-	agent := client.Agent()
+	agent := r.client.Agent()
 
 	for _, serviceID := range r.serviceIDs {
 		if err := agent.ServiceDeregister(serviceID); err != nil {

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -5,14 +5,8 @@ import (
 
 	"github.com/doubledutch/lager"
 	"github.com/doubledutch/quantum"
-	"github.com/doubledutch/quantum/consul"
 	"github.com/doubledutch/quantum/inmemory"
 )
-
-// NewClientResolver creates a default client resolver
-func NewClientResolver(config quantum.ClientResolverConfig) quantum.ClientResolver {
-	return consul.NewClientResolver(config)
-}
 
 // NewRegistry returns a default registry
 func NewRegistry() quantum.Registry {


### PR DESCRIPTION
The new consul resolver functionality requires the consul http and dns addresses. To support this initially, I inferred the ports. This however broke clients already using a consul resolver. Since this already breaking functionality, `NewClientResolver` requires different parameters than before to explicitly break older clients when updating.
